### PR TITLE
Anon funciton onSubmit

### DIFF
--- a/src/AddToRegistryForm.js
+++ b/src/AddToRegistryForm.js
@@ -22,7 +22,7 @@ export default class extends React.Component {
 
     render () {
         return (
-            <form onSubmit={this.props.onSend(this.state)}>
+            <form onSubmit={() => this.props.onSend(this.state)}>
                 <div className="form-group">
                     <label>Item name: </label>
                     <input type="text" id="item-name-field" onChange={this.updateItemName} />


### PR DESCRIPTION
The previous invocation in onSubmit would invoke `this.props.onSend(this.state)` on every render.  Containing it in an anonymous func ensures it only executes onSubmit